### PR TITLE
Track Solidus gem from main branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :test do
   gem "selenium-webdriver"
 end
 
-gem "solidus", github: "solidusio/solidus"
-gem "solidus_admin", github: "solidusio/solidus"
+gem "solidus", github: "solidusio/solidus", branch: "main"
+gem "solidus_admin", github: "solidusio/solidus", branch: "main"
 
 gem "tailwindcss-rails", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,8 @@ GIT
 
 GIT
   remote: https://github.com/solidusio/solidus.git
-  revision: 656afaa84d24c8c93b59061cac063f97f54f9ae3
+  revision: 49e3da4712329d8e89327039abf0f047c6d11424
+  branch: main
   specs:
     solidus (4.4.0.dev)
       solidus_api (= 4.4.0.dev)
@@ -204,8 +205,7 @@ GEM
       reline (>= 0.3.8)
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     erubi (1.12.0)
     execjs (2.9.1)
     factory_bot (6.4.6)
@@ -277,7 +277,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.2)
+    marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.0.0)
     mime-types (3.5.2)
@@ -353,7 +353,7 @@ GEM
     redis-client (0.20.0)
       connection_pool
     regexp_parser (2.9.0)
-    reline (0.4.2)
+    reline (0.4.3)
       io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
@@ -389,9 +389,8 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.0)
+    ruby-vips (2.2.1)
       ffi (~> 1.12)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -437,7 +436,7 @@ GEM
       railties (>= 6.0.0)
     terrapin (1.0.1)
       climate_control
-    thor (1.3.0)
+    thor (1.3.1)
     tilt (2.3.0)
     timeout (0.4.1)
     turbo-rails (1.5.0)


### PR DESCRIPTION
This was not being picked up by dependabot and I do want to keep up to date with Solidus main branch.